### PR TITLE
[FRONTEND] Add real-time configuration (ports and calibration) persistence

### DIFF
--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,0 +1,78 @@
+import { useCallback, useRef } from 'react';
+import { useApi } from '@/contexts/ApiContext';
+
+export const useAutoSave = () => {
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const timeoutRefs = useRef<{ [key: string]: NodeJS.Timeout }>({});
+  const configTimeoutRefs = useRef<{ [key: string]: NodeJS.Timeout }>({});
+
+  const savePortAutomatically = useCallback(async (robotType: 'leader' | 'follower', port: string) => {
+    if (!port.trim()) return;
+    
+    try {
+      await fetchWithHeaders(`${baseUrl}/save-robot-port`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          robot_type: robotType,
+          port: port.trim(),
+        }),
+      });
+      console.log(`Auto-saved ${robotType} port: ${port}`);
+    } catch (error) {
+      console.error(`Error saving ${robotType} port:`, error);
+    }
+  }, [baseUrl, fetchWithHeaders]);
+
+  const saveConfigAutomatically = useCallback(async (robotType: 'leader' | 'follower', configName: string) => {
+    if (!configName.trim()) return;
+    
+    try {
+      await fetchWithHeaders(`${baseUrl}/save-robot-config`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          robot_type: robotType,
+          config_name: configName.trim(),
+        }),
+      });
+      console.log(`Auto-saved ${robotType} config: ${configName}`);
+    } catch (error) {
+      console.error(`Error saving ${robotType} config:`, error);
+    }
+  }, [baseUrl, fetchWithHeaders]);
+
+  const debouncedSavePort = useCallback((robotType: 'leader' | 'follower', port: string, delay: number = 1500) => {
+    // Clear existing timeout for this robotType
+    if (timeoutRefs.current[robotType]) {
+      clearTimeout(timeoutRefs.current[robotType]);
+    }
+
+    // Set new timeout
+    timeoutRefs.current[robotType] = setTimeout(() => {
+      savePortAutomatically(robotType, port);
+      delete timeoutRefs.current[robotType];
+    }, delay);
+  }, [savePortAutomatically]);
+
+  const debouncedSaveConfig = useCallback((robotType: 'leader' | 'follower', configName: string, delay: number = 1000) => {
+    const key = `${robotType}_config`;
+    
+    // Clear existing timeout for this robotType config
+    if (configTimeoutRefs.current[key]) {
+      clearTimeout(configTimeoutRefs.current[key]);
+    }
+
+    // Set new timeout
+    configTimeoutRefs.current[key] = setTimeout(() => {
+      saveConfigAutomatically(robotType, configName);
+      delete configTimeoutRefs.current[key];
+    }, delay);
+  }, [saveConfigAutomatically]);
+
+  return { debouncedSavePort, debouncedSaveConfig };
+};


### PR DESCRIPTION
First of all, incredible work on LeLab! 🎉 Congratulations on building such an amazing UI for LeRobot.

### Problem Solved
- Manual port/config changes were lost on page refresh
- Settings only persisted when using "Find" button, not manual entry

### Changes Made
- **Custom hook**: `useAutoSave` with intelligent debounced saving
- **Auto-load on modal open**: All configuration modals now load saved settings automatically
- **Real-time persistence**: Save immediately when typing in text fields or selecting configs
- **Enhanced UX**: Seamless config recovery, no data loss between sessions
- **Smart debouncing**: 1.5s for ports (typing), 1s for configs (selection)

### Technical Implementation

#### New Files
- **`hooks/useAutoSave.ts`** - Centralized auto-save logic with debouncing
  - `debouncedSavePort()` - Auto-save ports with 1.5s delay
  - `debouncedSaveConfig()` - Auto-save configs with 1s delay
  - Separate timeout management for each robot type
  - Error handling and logging

#### Updated Components
- **`TeleoperationModal.tsx`** - Leader/Follower port + config persistence
- **`RecordingModal.tsx`** - Full recording setup persistence
- **`DirectFollowerModal.tsx`** - Follower-only configuration persistence

### Dependencies
- **Requires Backend PR**: [Link to backend PR](https://github.com/nicolas-rabault/leLab/pull/2)
- **API Endpoints Used**:
  - `GET /robot-port/{robot_type}` - Load saved ports
  - `POST /save-robot-port` - Save port changes
  - `GET /robot-config/{robot_type}` - Load saved configs
  - `POST /save-robot-config` - Save config selections